### PR TITLE
Made the route pattern match more specific and use the match? method instead of match

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # OpenStax Healthcheck
 
-[![Build Status](https://travis-ci.org/openstax/healthcheck.svg?branch=master)](https://travis-ci.org/openstax/healthcheck)
+[![Gem Version](https://badge.fury.io/rb/openstax_healthcheck.svg)](http://badge.fury.io/rb/openstax_healthcheck)
+[![Tests](https://github.com/openstax/healthcheck/workflows/Tests/badge.svg)](https://github.com/openstax/healthcheck/actions?query=workflow:Tests)
 
 This gem defines a route in your Rails app for ELB healthchecks.
 The only thing that this middleware does is return 200 OK if the route matches a regex pattern.

--- a/lib/openstax/healthcheck/middleware.rb
+++ b/lib/openstax/healthcheck/middleware.rb
@@ -1,14 +1,14 @@
 module OpenStax
   module Healthcheck
     class Middleware
-      ROUTE_PATTERN = /\/ping\/?/
+      ROUTE_PATTERN = /\A\/ping\/?\z/
 
       def initialize(app)
         @app = app
       end
 
       def call(env)
-        return [ 200, {}, [] ] if ROUTE_PATTERN.match env['PATH_INFO']
+        return [ 200, {}, [] ] if ROUTE_PATTERN.match? env['PATH_INFO']
 
         @app.call env
       end

--- a/lib/openstax/healthcheck/version.rb
+++ b/lib/openstax/healthcheck/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Healthcheck
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end


### PR DESCRIPTION
The more specific pattern is better to prevent matching urls that simply contain `/ping` somewhere
`match?` instead of match is a small speed improvement but for something that runs on every single request it's probably good.